### PR TITLE
md concordances, placetype local, and more

### DIFF
--- a/data/856/332/87/85633287.geojson
+++ b/data/856/332/87/85633287.geojson
@@ -1320,6 +1320,7 @@
         "hasc:id":"MD",
         "icao:code":"ER",
         "ioc:id":"MDA",
+        "iso:code":"MD",
         "itu:id":"MDA",
         "loc:id":"n90720192",
         "m49:code":"498",
@@ -1334,6 +1335,7 @@
         "wk:page":"Moldova",
         "wmo:id":"RM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MD",
     "wof:country_alpha3":"MDA",
     "wof:geom_alt":[
@@ -1356,7 +1358,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1694639630,
+    "wof:lastmodified":1695881292,
     "wof:name":"Moldova",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/863/31/85686331.geojson
+++ b/data/856/863/31/85686331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078138,
-    "geom:area_square_m":671701726.748632,
+    "geom:area_square_m":671701979.733698,
     "geom:bbox":"28.386345,45.725807,29.06705,46.231728",
     "geom:latitude":45.956409,
     "geom:longitude":28.680884,
@@ -211,10 +211,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":55948203,
+        "iso:code":"MD-TA",
+        "qs:local_id":"30",
         "wd:id":"Q865884"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"41196c8e0627a5d4774cd7663e956eb9",
+    "wof:geomhash":"bf293f1e07cdd9bb07f0c8cb66f69fb9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -229,7 +235,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939135,
+    "wof:lastmodified":1695884857,
     "wof:name":"Taraclia",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/35/85686335.geojson
+++ b/data/856/863/35/85686335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.179072,
-    "geom:area_square_m":1542355916.416871,
+    "geom:area_square_m":1542357056.385875,
     "geom:bbox":"28.085516,45.466312,28.563922,46.15385",
     "geom:latitude":45.848342,
     "geom:longitude":28.288904,
@@ -292,11 +292,17 @@
         "gn:id":618164,
         "gp:id":20069882,
         "hasc:id":"MD.CH",
+        "iso:code":"MD-CA",
         "iso:id":"MD-CA",
+        "qs:local_id":"04",
         "wd:id":"Q2128882"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"4dd36b27ebe15282281884fe7fc14b1d",
+    "wof:geomhash":"f6f1b48b5dd778d6e1dfb25285274fa3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -311,7 +317,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939134,
+    "wof:lastmodified":1695884857,
     "wof:name":"Cahul",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/43/85686343.geojson
+++ b/data/856/863/43/85686343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101351,
-    "geom:area_square_m":866697891.259773,
+    "geom:area_square_m":866698127.574003,
     "geom:bbox":"28.106409,46.07906,28.55607,46.420714",
     "geom:latitude":46.24511,
     "geom:longitude":28.334369,
@@ -318,12 +318,18 @@
         "gn:id":618142,
         "gp:id":55948182,
         "hasc:id":"MD.CN",
+        "iso:code":"MD-CT",
         "iso:id":"MD-CT",
+        "qs:local_id":"05",
         "unlc:id":"MD-CT",
         "wd:id":"Q684183"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"25d9c0fa1a5f29b535de280704014ad9",
+    "wof:geomhash":"34b4215e70df07aa56343d7e63beacab",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -338,7 +344,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939135,
+    "wof:lastmodified":1695884857,
     "wof:name":"Cantemir",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/49/85686349.geojson
+++ b/data/856/863/49/85686349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214934,
-    "geom:area_square_m":1843601638.726331,
+    "geom:area_square_m":1843602903.301687,
     "geom:bbox":"28.291314,45.485073,29.002199,46.471705",
     "geom:latitude":46.077067,
     "geom:longitude":28.651033,
@@ -360,11 +360,17 @@
         "gn:id":858895,
         "gp:id":20069881,
         "hasc:id":"MD.GA",
+        "iso:code":"MD-GA",
         "iso:id":"MD-GA",
+        "qs:local_id":"33",
         "wd:id":"Q164819"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"ba8a9c25a0e9011221b6214cc5736fff",
+    "wof:geomhash":"f23c4ae7d66f0501e363e374023ae35c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -379,7 +385,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1614895313,
+    "wof:lastmodified":1695884534,
     "wof:name":"Unitatea Teritotrial\u0103 Autonom\u0103 G\u0103g\u0103uzia",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/51/85686351.geojson
+++ b/data/856/863/51/85686351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034553,
-    "geom:area_square_m":294725058.134275,
+    "geom:area_square_m":294724798.458614,
     "geom:bbox":"28.727732,46.259514,29.025537,46.537432",
     "geom:latitude":46.38475,
     "geom:longitude":28.895359,
@@ -302,12 +302,18 @@
         "gn:id":618565,
         "gp:id":55948179,
         "hasc:id":"MD.BA",
+        "iso:code":"MD-BS",
         "iso:id":"MD-BS",
+        "qs:local_id":"02",
         "unlc:id":"MD-BS",
         "wd:id":"Q1980044"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"9367d9e74ae1446a0191d67e213f83f0",
+    "wof:geomhash":"651a6ff58ff4753495c20a1541ee7be2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -322,7 +328,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939134,
+    "wof:lastmodified":1695884857,
     "wof:name":"Basarabeasca",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/55/85686355.geojson
+++ b/data/856/863/55/85686355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089669,
-    "geom:area_square_m":762916087.187796,
+    "geom:area_square_m":762916519.732989,
     "geom:bbox":"28.209364,46.336619,28.580234,46.70682",
     "geom:latitude":46.522181,
     "geom:longitude":28.411905,
@@ -293,12 +293,18 @@
         "gn:id":617903,
         "gp:id":55948193,
         "hasc:id":"MD.LE",
+        "iso:code":"MD-LE",
         "iso:id":"MD-LE",
+        "qs:local_id":"19",
         "unlc:id":"MD-LE",
         "wd:id":"Q1826662"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"541bc09b5768e777fad9b989d87d8c59",
+    "wof:geomhash":"12e9367028543cb1df0850edb548a0e1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -313,7 +319,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939136,
+    "wof:lastmodified":1695884857,
     "wof:name":"Leova",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/59/85686359.geojson
+++ b/data/856/863/59/85686359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108323,
-    "geom:area_square_m":920598904.442786,
+    "geom:area_square_m":920599000.607817,
     "geom:bbox":"28.549448,46.412439,29.063154,46.771857",
     "geom:latitude":46.582947,
     "geom:longitude":28.776325,
@@ -304,12 +304,18 @@
         "gn:id":618430,
         "gp:id":55948184,
         "hasc:id":"MD.CS",
+        "iso:code":"MD-CM",
         "iso:id":"MD-CM",
+        "qs:local_id":"08",
         "unlc:id":"MD-CM",
         "wd:id":"Q286646"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"df190e6d566a1b07515ea44ce0a05c74",
+    "wof:geomhash":"d0aaac9296973d8e90caddf8fd4e04f7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -324,7 +330,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939134,
+    "wof:lastmodified":1695884534,
     "wof:name":"Cimi\u015flia",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/65/85686365.geojson
+++ b/data/856/863/65/85686365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117121,
-    "geom:area_square_m":996822935.021719,
+    "geom:area_square_m":996824310.413804,
     "geom:bbox":"29.396099,46.352474,30.163524,46.678984",
     "geom:latitude":46.503676,
     "geom:longitude":29.716802,
@@ -315,12 +315,18 @@
         "gn:id":617283,
         "gp:id":55948200,
         "hasc:id":"MD.SV",
+        "iso:code":"MD-SV",
         "iso:id":"MD-SV",
+        "qs:local_id":"29",
         "unlc:id":"MD-SV",
         "wd:id":"Q2129061"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"00374ecf756dc5bb4f3f0ea3c20f93f8",
+    "wof:geomhash":"dd21ae3ae262fe821b1cbda53af7b624",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -335,7 +341,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939136,
+    "wof:lastmodified":1695884534,
     "wof:name":"\u015etefan Vod\u0103",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/69/85686369.geojson
+++ b/data/856/863/69/85686369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004495,
-    "geom:area_square_m":38032055.563962,
+    "geom:area_square_m":38031953.275223,
     "geom:bbox":"29.395008,46.781215,29.510378,46.863503",
     "geom:latitude":46.827222,
     "geom:longitude":29.454532,
@@ -141,10 +141,16 @@
         "gn:id":861487,
         "gp:id":20069877,
         "hasc:id":"MD.BD",
-        "iso:id":"MD-BD"
+        "iso:code":"MD-BD",
+        "iso:id":"MD-BD",
+        "qs:local_id":"37"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"714092480f6185f52c73cd3e84241d79",
+    "wof:geomhash":"5e1e66c877b60ab96bb34e9ef6b91e67",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -159,7 +165,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1627522350,
+    "wof:lastmodified":1695884755,
     "wof:name":"mun.Bender",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/73/85686373.geojson
+++ b/data/856/863/73/85686373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.154516,
-    "geom:area_square_m":1311572488.979802,
+    "geom:area_square_m":1311573256.116873,
     "geom:bbox":"28.923125,46.376175,29.694597,46.834303",
     "geom:latitude":46.649092,
     "geom:longitude":29.324223,
@@ -305,12 +305,18 @@
         "gn:id":618119,
         "gp:id":55948183,
         "hasc:id":"MD.CU",
+        "iso:code":"MD-CS",
         "iso:id":"MD-CS",
+        "qs:local_id":"07",
         "unlc:id":"MD-CS",
         "wd:id":"Q2128869"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"cfe85fa114e93b604887d21476a3c418",
+    "wof:geomhash":"84dd5bdb9f57e7ee3ad1d044d8a37684",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -325,7 +331,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939134,
+    "wof:lastmodified":1695884534,
     "wof:name":"C\u0103u\u015feni",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/77/85686377.geojson
+++ b/data/856/863/77/85686377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17355,
-    "geom:area_square_m":1467983818.504549,
+    "geom:area_square_m":1467984682.486657,
     "geom:bbox":"28.083038,46.604465,28.742723,47.089652",
     "geom:latitude":46.838032,
     "geom:longitude":28.406649,
@@ -302,11 +302,17 @@
         "gn:id":858803,
         "gp:id":55948191,
         "hasc:id":"MD.HI",
+        "iso:code":"MD-HI",
         "iso:id":"MD-HI",
+        "qs:local_id":"17",
         "wd:id":"Q878297"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"5a58c1ce1cc3b0d73426e889a9f8bc68",
+    "wof:geomhash":"492bc30c581c243344700bb949c7874a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -321,7 +327,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939136,
+    "wof:lastmodified":1695884534,
     "wof:name":"H\u00eence\u015fti",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/85/85686385.geojson
+++ b/data/856/863/85/85686385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092345,
-    "geom:area_square_m":780974118.161619,
+    "geom:area_square_m":780974118.161521,
     "geom:bbox":"28.464126,46.656346,29.102995,47.07572",
     "geom:latitude":46.846969,
     "geom:longitude":28.821906,
@@ -296,12 +296,18 @@
         "gn:id":617991,
         "gp:id":55948192,
         "hasc:id":"MD.IA",
+        "iso:code":"MD-IA",
         "iso:id":"MD-IA",
+        "qs:local_id":"18",
         "unlc:id":"MD-IA",
         "wd:id":"Q2128964"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"72e7ae73ba8cebef1c140478088e1d90",
+    "wof:geomhash":"26387ee76dc5ddc7641fda025661b934",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -316,7 +322,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939136,
+    "wof:lastmodified":1695884857,
     "wof:name":"Ialoveni",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/87/85686387.geojson
+++ b/data/856/863/87/85686387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074465,
-    "geom:area_square_m":626930819.832163,
+    "geom:area_square_m":626931174.847805,
     "geom:bbox":"27.944627,46.905701,28.328882,47.259777",
     "geom:latitude":47.087835,
     "geom:longitude":28.133977,
@@ -293,12 +293,18 @@
         "gn:id":617754,
         "gp:id":55948194,
         "hasc:id":"MD.NI",
+        "iso:code":"MD-NI",
         "iso:id":"MD-NI",
+        "qs:local_id":"20",
         "unlc:id":"MD-NI",
         "wd:id":"Q878266"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"37d01128f5ea0145acf816953c0102da",
+    "wof:geomhash":"a205db6f7540901ad0d2d6f34509fbe5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -313,7 +319,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939135,
+    "wof:lastmodified":1695884857,
     "wof:name":"Nisporeni",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/91/85686391.geojson
+++ b/data/856/863/91/85686391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067465,
-    "geom:area_square_m":568754512.275121,
+    "geom:area_square_m":568754512.275114,
     "geom:bbox":"28.630944,46.85811,29.123422,47.15633",
     "geom:latitude":47.016574,
     "geom:longitude":28.871173,
@@ -156,12 +156,18 @@
         "gn:id":618069,
         "gp:id":20069878,
         "hasc:id":"MD.CV",
+        "iso:code":"MD-CU",
         "iso:id":"MD-CU",
+        "qs:local_id":"35",
         "unlc:id":"MD-CU",
         "wd:id":"Q5341085"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"8b8134cc69ef0e076e5def392cfc5666",
+    "wof:geomhash":"ca121d6b8f7e8d6413f22ab25fda1dd1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -176,7 +182,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1627522350,
+    "wof:lastmodified":1695884755,
     "wof:name":"mun.Chi\u015fin\u0103u",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/863/95/85686395.geojson
+++ b/data/856/863/95/85686395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10481,
-    "geom:area_square_m":885376790.005802,
+    "geom:area_square_m":885376794.14215,
     "geom:bbox":"28.949737,46.707797,29.489288,47.139215",
     "geom:latitude":46.908346,
     "geom:longitude":29.227842,
@@ -306,12 +306,18 @@
         "gn:id":617715,
         "gp:id":55948205,
         "hasc:id":"MD.AN",
+        "iso:code":"MD-AN",
         "iso:id":"MD-AN",
+        "qs:local_id":"01",
         "unlc:id":"MD-AN",
         "wd:id":"Q769224"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"217ef3e342979c3ae905c04edceb88ea",
+    "wof:geomhash":"a8416bcd4b054b3bd1fcb52b0e7e1b17",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -326,7 +332,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939133,
+    "wof:lastmodified":1695884857,
     "wof:name":"Anenii Noi",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/05/85686405.geojson
+++ b/data/856/864/05/85686405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086855,
-    "geom:area_square_m":730224419.120608,
+    "geom:area_square_m":730224419.120609,
     "geom:bbox":"28.232544,46.988302,28.785159,47.335154",
     "geom:latitude":47.161958,
     "geom:longitude":28.542498,
@@ -296,12 +296,18 @@
         "gn:id":617301,
         "gp:id":55948202,
         "hasc:id":"MD.ST",
+        "iso:code":"MD-ST",
         "iso:id":"MD-ST",
+        "qs:local_id":"27",
         "unlc:id":"MD-ST",
         "wd:id":"Q878308"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"6ecb9e6d3e4a439b745472227097f4a9",
+    "wof:geomhash":"d2f2f3fa537c23520dc45e43cc91d6e6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -316,7 +322,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939129,
+    "wof:lastmodified":1695884534,
     "wof:name":"Str\u0103\u015feni",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/09/85686409.geojson
+++ b/data/856/864/09/85686409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128899,
-    "geom:area_square_m":1080654056.770517,
+    "geom:area_square_m":1080655749.315426,
     "geom:bbox":"27.573679,47.022938,28.195952,47.490891",
     "geom:latitude":47.311421,
     "geom:longitude":27.905918,
@@ -310,12 +310,18 @@
         "gn:id":617181,
         "gp:id":20069874,
         "hasc:id":"MD.UG",
+        "iso:code":"MD-UN",
         "iso:id":"MD-UN",
+        "qs:local_id":"32",
         "unlc:id":"MD-UN",
         "wd:id":"Q854443"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"d91f67cc6ce318cdcdd8b680624b707f",
+    "wof:geomhash":"e34ece3cc04925090c06f263a954f7e1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -330,7 +336,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939130,
+    "wof:lastmodified":1695884856,
     "wof:name":"Ungheni",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/13/85686413.geojson
+++ b/data/856/864/13/85686413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081845,
-    "geom:area_square_m":688155280.754069,
+    "geom:area_square_m":688155280.754065,
     "geom:bbox":"28.747289,46.969496,29.296111,47.327144",
     "geom:latitude":47.158127,
     "geom:longitude":29.023902,
@@ -208,10 +208,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":55948185,
+        "iso:code":"MD-CR",
+        "qs:local_id":"09",
         "wd:id":"Q2128862"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"e34044f42b76763657170b90a4311214",
+    "wof:geomhash":"d62dcd179e7fbad88048282eca97f911",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -226,7 +232,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939133,
+    "wof:lastmodified":1695884856,
     "wof:name":"Criuleni",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/23/85686423.geojson
+++ b/data/856/864/23/85686423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089499,
-    "geom:area_square_m":750493688.3539,
+    "geom:area_square_m":750493688.353984,
     "geom:bbox":"28.046794,47.159029,28.564425,47.446533",
     "geom:latitude":47.300505,
     "geom:longitude":28.30589,
@@ -302,12 +302,18 @@
         "gn:id":618162,
         "gp:id":55948181,
         "hasc:id":"MD.CA",
+        "iso:code":"MD-CL",
         "iso:id":"MD-CL",
+        "qs:local_id":"06",
         "unlc:id":"MD-CL",
         "wd:id":"Q2128868"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"a913d77c4534a3b351cb96454a7bc35a",
+    "wof:geomhash":"6832d94ee0c8dd362446c8b3fd2059dc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -322,7 +328,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939132,
+    "wof:lastmodified":1695884534,
     "wof:name":"C\u0103l\u0103ra\u015fi",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/27/85686427.geojson
+++ b/data/856/864/27/85686427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038848,
-    "geom:area_square_m":325971508.215986,
+    "geom:area_square_m":325971499.352635,
     "geom:bbox":"28.990795,47.075169,29.363381,47.414763",
     "geom:latitude":47.266714,
     "geom:longitude":29.15557,
@@ -217,11 +217,17 @@
     "wof:concordances":{
         "fips:code":"MD72",
         "hasc:id":"MD.DB",
+        "iso:code":"MD-DU",
         "iso:id":"MD-DU",
+        "qs:local_id":"12",
         "wd:id":"Q878278"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"06c4385785f5d3a3bd77e91ad0b4687d",
+    "wof:geomhash":"dc1478c35d698c5684226567d32f5f2a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -243,7 +249,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939129,
+    "wof:lastmodified":1695884534,
     "wof:name":"Dub\u0103sari",
     "wof:parent_id":1159339529,
     "wof:placetype":"region",

--- a/data/856/864/31/85686431.geojson
+++ b/data/856/864/31/85686431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.39832,
-    "geom:area_square_m":3337293583.416382,
+    "geom:area_square_m":3337288764.813304,
     "geom:bbox":"28.491888,46.546673,29.979357,48.182144",
     "geom:latitude":47.343386,
     "geom:longitude":29.326008,
@@ -76,10 +76,16 @@
         "fips:code":"MD58",
         "gp:id":55948201,
         "hasc:id":"MD.DU",
-        "iso:id":"MD-SN"
+        "iso:code":"MD-SN",
+        "iso:id":"MD-SN",
+        "qs:local_id":"34"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"7514de712fea9c60fbea0cec4e1fefcd",
+    "wof:geomhash":"d0e6cdd282146f83cf2078f1d2983feb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -101,7 +107,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1627522350,
+    "wof:lastmodified":1695884755,
     "wof:name":"UAT din St\u00eenga Nistrului",
     "wof:parent_id":1159339529,
     "wof:placetype":"region",

--- a/data/856/864/37/85686437.geojson
+++ b/data/856/864/37/85686437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128173,
-    "geom:area_square_m":1069248430.643663,
+    "geom:area_square_m":1069249223.98127,
     "geom:bbox":"27.401783,47.373825,28.003247,47.777435",
     "geom:latitude":47.572369,
     "geom:longitude":27.720079,
@@ -302,12 +302,18 @@
         "gn:id":618345,
         "gp:id":55948188,
         "hasc:id":"MD.FA",
+        "iso:code":"MD-FA",
         "iso:id":"MD-FA",
+        "qs:local_id":"14",
         "unlc:id":"MD-FA",
         "wd:id":"Q878375"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"00aee9cb4a2ecb76b187bf7e2dae19b0",
+    "wof:geomhash":"2665499b6e57356a1efa81d4cf4d042e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -322,7 +328,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939131,
+    "wof:lastmodified":1695884534,
     "wof:name":"F\u0103le\u015fti",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/41/85686441.geojson
+++ b/data/856/864/41/85686441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146098,
-    "geom:area_square_m":1222426405.157626,
+    "geom:area_square_m":1222426384.781393,
     "geom:bbox":"28.496808,47.178606,29.118496,47.621793",
     "geom:latitude":47.415914,
     "geom:longitude":28.797832,
@@ -300,12 +300,18 @@
         "gn:id":617639,
         "gp:id":20069875,
         "hasc:id":"MD.OH",
+        "iso:code":"MD-OR",
         "iso:id":"MD-OR",
+        "qs:local_id":"22",
         "unlc:id":"MD-OR",
         "wd:id":"Q2112462"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"243ad9b0297f1c484b92fde564bd3d07",
+    "wof:geomhash":"bb047599593515bbdd023413bef439cf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -320,7 +326,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939132,
+    "wof:lastmodified":1695884856,
     "wof:name":"Orhei",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/45/85686445.geojson
+++ b/data/856/864/45/85686445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090657,
-    "geom:area_square_m":753854801.270446,
+    "geom:area_square_m":753855466.231102,
     "geom:bbox":"27.249904,47.584247,27.804586,47.870067",
     "geom:latitude":47.740244,
     "geom:longitude":27.507621,
@@ -293,12 +293,18 @@
         "gn:id":618260,
         "gp:id":55948190,
         "hasc:id":"MD.GL",
+        "iso:code":"MD-GL",
         "iso:id":"MD-GL",
+        "qs:local_id":"16",
         "unlc:id":"MD-GL",
         "wd:id":"Q860716"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"7ebc7c072b46a4758efddb5051eee96d",
+    "wof:geomhash":"570e2f3794c18ac439002404ea51c374",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -313,7 +319,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939129,
+    "wof:lastmodified":1695884856,
     "wof:name":"Glodeni",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/49/85686449.geojson
+++ b/data/856/864/49/85686449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009299,
-    "geom:area_square_m":77273267.58313,
+    "geom:area_square_m":77273267.583123,
     "geom:bbox":"27.783484,47.728639,28.050791,47.824823",
     "geom:latitude":47.774082,
     "geom:longitude":27.931201,
@@ -374,12 +374,18 @@
         "gn:id":873909,
         "gp:id":20069873,
         "hasc:id":"MD.BT",
+        "iso:code":"MD-BA",
         "iso:id":"MD-BA",
+        "qs:local_id":"36",
         "unlc:id":"MD-BA",
         "wd:id":"Q4484005"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"ac1738db3897363740d27fdd5794042a",
+    "wof:geomhash":"f19e5369ce10cc1720a2aec226fab9b8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -394,7 +400,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1614895312,
+    "wof:lastmodified":1695884534,
     "wof:name":"mun.B\u0103l\u0163i",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/55/85686455.geojson
+++ b/data/856/864/55/85686455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10139,
-    "geom:area_square_m":846111769.959167,
+    "geom:area_square_m":846111769.959144,
     "geom:bbox":"28.141771,47.394889,28.704946,47.73796",
     "geom:latitude":47.554285,
     "geom:longitude":28.439682,
@@ -319,12 +319,18 @@
         "gn:id":617255,
         "gp:id":55948204,
         "hasc:id":"MD.TE",
+        "iso:code":"MD-TE",
         "iso:id":"MD-TE",
+        "qs:local_id":"31",
         "unlc:id":"MD-TE",
         "wd:id":"Q2129025"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"51befca7ea34a358f9a62aee1e72d6f6",
+    "wof:geomhash":"f7c05506f6ec6af25e72754b4675ad7d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -339,7 +345,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939131,
+    "wof:lastmodified":1695884534,
     "wof:name":"Telene\u015fti",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/59/85686459.geojson
+++ b/data/856/864/59/85686459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.123736,
-    "geom:area_square_m":1030477469.453386,
+    "geom:area_square_m":1030477469.453461,
     "geom:bbox":"27.886259,47.434357,28.406934,47.910257",
     "geom:latitude":47.661502,
     "geom:longitude":28.118454,
@@ -289,12 +289,18 @@
         "gn:id":617913,
         "gp:id":55948198,
         "hasc:id":"MD.SI",
+        "iso:code":"MD-SI",
         "iso:id":"MD-SI",
+        "qs:local_id":"25",
         "unlc:id":"MD-SI",
         "wd:id":"Q1796621"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"35e047677728a16ac5fe0367bf935c61",
+    "wof:geomhash":"ce9aa3c98bdeb9813aeee577d62cd13a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939128,
+    "wof:lastmodified":1695884534,
     "wof:name":"S\u00eengerei",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/63/85686463.geojson
+++ b/data/856/864/63/85686463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112808,
-    "geom:area_square_m":934871537.219326,
+    "geom:area_square_m":934872195.254236,
     "geom:bbox":"27.150465,47.754951,27.919883,48.092983",
     "geom:latitude":47.916709,
     "geom:longitude":27.492542,
@@ -305,11 +305,17 @@
         "gn:id":617483,
         "gp:id":55948197,
         "hasc:id":"MD.RS",
+        "iso:code":"MD-RI",
         "iso:id":"MD-RI",
+        "qs:local_id":"24",
         "wd:id":"Q611656"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"f9a2cfe5ca58073545d9b928ee2294c2",
+    "wof:geomhash":"273822fef24d05795c0d409a13b114b4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -324,7 +330,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939131,
+    "wof:lastmodified":1695884534,
     "wof:name":"R\u00ee\u015fcani",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/67/85686467.geojson
+++ b/data/856/864/67/85686467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074394,
-    "geom:area_square_m":619186782.778898,
+    "geom:area_square_m":619186766.585876,
     "geom:bbox":"28.595144,47.524892,29.027752,47.884392",
     "geom:latitude":47.693014,
     "geom:longitude":28.853812,
@@ -220,12 +220,18 @@
     "wof:concordances":{
         "fips:code":"MD83",
         "hasc:id":"MD.RZ",
+        "iso:code":"MD-RE",
         "iso:id":"MD-RE",
+        "qs:local_id":"23",
         "unlc:id":"MD-RE",
         "wd:id":"Q878317"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"4ec5bbed7ba6c54eff1ebb5bffc41ff1",
+    "wof:geomhash":"d11dc744f10df1721b2480a25ff44fd5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -240,7 +246,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939128,
+    "wof:lastmodified":1695884856,
     "wof:name":"Rezina",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/73/85686473.geojson
+++ b/data/856/864/73/85686473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07168,
-    "geom:area_square_m":594972868.440249,
+    "geom:area_square_m":594972868.440273,
     "geom:bbox":"28.403025,47.703208,28.975684,47.987119",
     "geom:latitude":47.834991,
     "geom:longitude":28.683393,
@@ -309,12 +309,18 @@
         "gn:id":858808,
         "gp:id":55948199,
         "hasc:id":"MD.SD",
+        "iso:code":"MD-SD",
         "iso:id":"MD-SD",
+        "qs:local_id":"28",
         "unlc:id":"MD-SD",
         "wd:id":"Q865639"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"7d085a9db24325656bb511b76d4e8760",
+    "wof:geomhash":"3ca6c893adb5929669cbed0dbcbb4594",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -329,7 +335,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939129,
+    "wof:lastmodified":1695884534,
     "wof:name":"Sold\u0103ne\u015fti",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/77/85686477.geojson
+++ b/data/856/864/77/85686477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133278,
-    "geom:area_square_m":1105022101.793932,
+    "geom:area_square_m":1105022101.794007,
     "geom:bbox":"28.023286,47.690938,28.757949,48.070742",
     "geom:latitude":47.892792,
     "geom:longitude":28.365421,
@@ -326,12 +326,18 @@
         "gn:id":618331,
         "gp:id":55948189,
         "hasc:id":"MD.FL",
+        "iso:code":"MD-FL",
         "iso:id":"MD-FL",
+        "qs:local_id":"15",
         "unlc:id":"MD-FL",
         "wd:id":"Q865726"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"e15a09656928ae370078488c5015f2b8",
+    "wof:geomhash":"fa30b521f1ba76be9046df03f12af781",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -346,7 +352,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939132,
+    "wof:lastmodified":1695884534,
     "wof:name":"Flore\u015fti",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/81/85686481.geojson
+++ b/data/856/864/81/85686481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120679,
-    "geom:area_square_m":997768507.819674,
+    "geom:area_square_m":997768507.819692,
     "geom:bbox":"27.62378,47.820166,28.090558,48.240592",
     "geom:latitude":48.037179,
     "geom:longitude":27.857902,
@@ -298,12 +298,18 @@
         "gn:id":618369,
         "gp:id":55948187,
         "hasc:id":"MD.DR",
+        "iso:code":"MD-DR",
         "iso:id":"MD-DR",
+        "qs:local_id":"11",
         "unlc:id":"MD-DR",
         "wd:id":"Q865594"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"82f52be4283eee6841a96607eed70680",
+    "wof:geomhash":"70847380eae41512b0df71f80c7330a8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +324,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939130,
+    "wof:lastmodified":1695884534,
     "wof:name":"Drocia",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/85/85686485.geojson
+++ b/data/856/864/85/85686485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112704,
-    "geom:area_square_m":930088570.232746,
+    "geom:area_square_m":930089279.098313,
     "geom:bbox":"27.021826,47.940238,27.541902,48.349075",
     "geom:latitude":48.133556,
     "geom:longitude":27.277475,
@@ -303,12 +303,18 @@
         "gn:id":617077,
         "gp:id":20069871,
         "hasc:id":"MD.ED",
+        "iso:code":"MD-ED",
         "iso:id":"MD-ED",
+        "qs:local_id":"13",
         "unlc:id":"MD-ED",
         "wd:id":"Q878290"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"6cffd25db2a8fa36b9c5d8f328b102bf",
+    "wof:geomhash":"fe04eac96877afd0ccf4aa9099e0e41a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -323,7 +329,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939133,
+    "wof:lastmodified":1695884534,
     "wof:name":"Edine\u0163",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/864/97/85686497.geojson
+++ b/data/856/864/97/85686497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09894,
-    "geom:area_square_m":813921141.015712,
+    "geom:area_square_m":813921075.076443,
     "geom:bbox":"26.616332,48.121887,27.279233,48.434597",
     "geom:latitude":48.295461,
     "geom:longitude":26.97694,
@@ -305,12 +305,18 @@
         "gn:id":618511,
         "gp:id":55948180,
         "hasc:id":"MD.BR",
+        "iso:code":"MD-BR",
         "iso:id":"MD-BR",
+        "qs:local_id":"03",
         "unlc:id":"MD-BR",
         "wd:id":"Q753795"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"7479682c4e6c2a6fd29a4bdc1f4d8c71",
+    "wof:geomhash":"c7e1dbaddf30ebd0dd8ff488337ddd65",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -325,7 +331,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939131,
+    "wof:lastmodified":1695884857,
     "wof:name":"Briceni",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/865/01/85686501.geojson
+++ b/data/856/865/01/85686501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125642,
-    "geom:area_square_m":1036759974.476107,
+    "geom:area_square_m":1036758305.843231,
     "geom:bbox":"27.816707,47.975261,28.635361,48.353981",
     "geom:latitude":48.138687,
     "geom:longitude":28.193914,
@@ -297,12 +297,18 @@
         "gn:id":617366,
         "gp:id":20069872,
         "hasc:id":"MD.SO",
+        "iso:code":"MD-SO",
         "iso:id":"MD-SO",
+        "qs:local_id":"26",
         "unlc:id":"MD-SO",
         "wd:id":"Q2129022"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"b748364cc15f7861fed2a145cf00ffac",
+    "wof:geomhash":"c6404b182d02053710801777ceaa3bf1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -317,7 +323,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939128,
+    "wof:lastmodified":1695884856,
     "wof:name":"Soroca",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/865/05/85686505.geojson
+++ b/data/856/865/05/85686505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07808,
-    "geom:area_square_m":643011662.642616,
+    "geom:area_square_m":643011646.427345,
     "geom:bbox":"27.486895,48.046945,27.95406,48.386489",
     "geom:latitude":48.240418,
     "geom:longitude":27.669458,
@@ -303,12 +303,18 @@
         "gn:id":618381,
         "gp:id":55948186,
         "hasc:id":"MD.DO",
+        "iso:code":"MD-DO",
         "iso:id":"MD-DO",
+        "qs:local_id":"10",
         "unlc:id":"MD-DO",
         "wd:id":"Q1061128"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"9307078fd80b9ce93e6ef381064abe5e",
+    "wof:geomhash":"5c7be12570ff20b0302fae8f5544022f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -323,7 +329,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939127,
+    "wof:lastmodified":1695884534,
     "wof:name":"Dondu\u015feni",
     "wof:parent_id":85633287,
     "wof:placetype":"region",

--- a/data/856/865/11/85686511.geojson
+++ b/data/856/865/11/85686511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072615,
-    "geom:area_square_m":596481985.980212,
+    "geom:area_square_m":596480557.925124,
     "geom:bbox":"27.216501,48.215137,27.880563,48.492065",
     "geom:latitude":48.370923,
     "geom:longitude":27.526945,
@@ -311,11 +311,17 @@
         "gn:id":617656,
         "gp:id":55948195,
         "hasc:id":"MD.OC",
+        "iso:code":"MD-OC",
         "iso:id":"MD-OC",
+        "qs:local_id":"21",
         "wd:id":"Q266444"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MD",
-    "wof:geomhash":"665213a7c31f8af891577e6fdf021f23",
+    "wof:geomhash":"64cc49ed50ff74f33b161a31c59d99ac",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -330,7 +336,7 @@
     "wof:lang_x_spoken":[
         "ron"
     ],
-    "wof:lastmodified":1690939127,
+    "wof:lastmodified":1695884534,
     "wof:name":"Ocni\u0163a",
     "wof:parent_id":85633287,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.